### PR TITLE
fixed doc typos

### DIFF
--- a/lib/Getopt/Lucid.pm
+++ b/lib/Getopt/Lucid.pm
@@ -1128,7 +1128,7 @@ leading dashes. E.g.
     Keypair("--define|-D"),
   );
 
-  $opt = Getopt::Long->getopt( \@spec );
+  $opt = Getopt::Lucid->getopt( \@spec );
   print $opt->get_test ? "True" : "False";
   $opt->set_test(1);
 
@@ -1139,7 +1139,7 @@ calls.  E.g.
     Param("--input-file|-i")
   );
 
-  $opt = Getopt::Long->getopt( \@spec );
+  $opt = Getopt::Lucid->getopt( \@spec );
   print $opt->get_input_file;
 
 This can create an ambiguous case if a similar option exists with underscores


### PR DESCRIPTION
Hey David,

You had a couple typos in the doc examples where you wrote Getopt::Long instead of Getopt::Lucid!  They're fixed in this commit.

Best,
Nick Patch
