### PR TITLE
Automatic "usage" using a doc() modifier

### DIFF
--- a/lib/Getopt/Lucid.pm
+++ b/lib/Getopt/Lucid.pm
@@ -1082,6 +1082,17 @@ argument is needed.
     Switch("help|h")->anycase(),    # "Help", "HELP", etc.
   );
 
+=== doc()
+
+Sets the documentation string for an option.
+
+    @spec = (
+      Param("output")->doc("write output to the specified file"),
+    );
+
+This string shows up in the "usage" Getopt::Lucid attaches to the exception
+thrown when the command-line is invalid.
+
 == Validation
 
 Validation happens in two stages.  First, individual parameters may have
@@ -1298,13 +1309,16 @@ contains incorrect or invalid data
 processed and fails to pass specified validation, requirements, or is
 otherwise determined to be invalid
 
-These exception may be caught using an {eval} block and allow the calling
+These exceptions may be caught using an {eval} block and allow the calling
 program to respond differently to each class of exception.
+
+{Getopt::Lucid::Exception::ARGV} comes with an additional {usage} field you
+can use to display a "usage" made out of your option specification.
 
   my $opt;
   eval { $opt = Getopt::Lucid->getopt( \@spec ) };
   if ($@) {
-    print "$@\n" && print_usage() && exit 1
+    print "$@\n" && print $@->usage and exit 1
       if ref $@ eq 'Getopt::Lucid::Exception::ARGV';
     ref $@ ? $@->rethrow : die $@;
   }

--- a/lib/Getopt/Lucid.pm
+++ b/lib/Getopt/Lucid.pm
@@ -385,10 +385,9 @@ sub _build_usage {
     }
 
     # Can't use List::Util::max without a new dependency because of "use 5.006"
-    my $max_width = 4 + do {
+    my $max_width = 3 + do {
         my $m = -1;
-        do { $a = length $_->[0]; $m = $a if $m < $a }
-          for @doc;
+        do { $a = length $_->[0]; $m = $a if $m < $a } for @doc;
         $m;
     };
 

--- a/lib/Getopt/Lucid.pm
+++ b/lib/Getopt/Lucid.pm
@@ -24,7 +24,7 @@ my $VALID_NAME      = qr/$VALID_LONG|$VALID_SHORT|$VALID_BARE/;
 my $SHORT_BUNDLE    = qr/-[$VALID_STARTCHAR]{2,}/;
 my $NEGATIVE        = qr/(?:--)?no-/;
 
-my @valid_keys = qw( name type default nocase valid needs canon );
+my @valid_keys = qw( name type default nocase valid needs canon doc );
 my @valid_types = qw( switch counter parameter list keypair);
 
 sub Switch  {
@@ -90,6 +90,8 @@ sub default {
 sub anycase { my $self = shift; $self->{nocase}=1; return $self };
 
 sub needs { my $self = shift; $self->{needs}=[@_]; return $self };
+
+sub doc { my $self = shift; $self->{doc}=shift; return $self };
 
 package Getopt::Lucid;
 

--- a/lib/Getopt/Lucid/Exception.pm
+++ b/lib/Getopt/Lucid/Exception.pm
@@ -20,6 +20,7 @@ use Exception::Class 1.23 (
 
     "Getopt::Lucid::Exception::ARGV" => {
         description => "Invalid argument on command line",
+        fields => ['usage'],
     },
 
     "Getopt::Lucid::Exception::Usage" => {
@@ -36,7 +37,7 @@ my %throwers = (
 
 for my $t ( keys %throwers ) {
     no strict 'refs';
-    *{$t} = sub { $throwers{$t}->throw("$_[0]\n") };
+    *{$t} = sub { $throwers{$t}->throw(message => "$_[0]\n", @_[1..$#_]) };
 }
 
 1;


### PR DESCRIPTION
Hello Sir,

I have often used this great module and I appreciate its clarity and efficiency. But today, after a lot of App::Cmd (and thus Getopt::Long::Descriptive), I missed the autogenerated "usage" text of G::L::Descriptive in G::Lucid. These "usages" are always the same boring thing to write; you already specified your options to G::Lucid and you don't want to write them again; and you forget to update that usage when you change G::Lucid's specifications, etc. I figured out that G::Lucid's design made it easy to add that feature, so here I am!

These four commits implement a `doc()` modifier on G::Lucid::Spec objects (to attach a description string to an option), build a "usage" text in G::Lucid objects from strings provided by doc() and attach this usage to G::Lucid::Exception::ARGV so that users can catch command-line errors this way (note the `$@->usage`):

``` perl
if ($@) {
  print "$@\n" && print $@->usage and exit 1
    if ref $@ eq 'Getopt::Lucid::Exception::ARGV';
  ...
```

instead of:

``` perl
if ($@) {
  print "$@\n" && print_usage() && exit 1
    if ref $@ eq 'Getopt::Lucid::Exception::ARGV';
  ...
```

where they need to write `print_usage` themselves.

Some things I'm not happy about in these commits:
- being forced to always pass `usage => $self->{usage}` in `throw_argv()`, but since `throw_argv()` isn't a G::Lucid method…
- no way to customize the autogenerated "usage" (I can't think of how I would like to customize it, though);
- this ugly `max` implementation in `_build_usage()` (but using `List::Util::max()` would mean adding an external dependency, since List::Util seems not to be in 5.6's core, and I believed it was not worth it for just a `max`);
- for a moment I tried to incorporate G::Lucid::Spec's `type` fields (_keypair_, _list_, etc.) in the "usage", but I ended up with overly long lines so I forgot that idea.

I hope you'll find this useful anyway, so that soon we'll have no need to write these boring "usages" by hand!
