### PR TITLE
Better error message when validate() requires an unspecified option

### DIFF
--- a/lib/Getopt/Lucid.pm
+++ b/lib/Getopt/Lucid.pm
@@ -234,6 +234,8 @@ sub validate {
     throw_usage("'validate' argument 'requires' must be an array reference")
       if $requires && ref($requires) ne 'ARRAY';
     for my $p ( @$requires ) {
+        throw_spec("Requiring an unspecified option ('$p') in validate()")
+            unless exists $self->{spec}{$p};
         throw_argv("Required option '$self->{spec}{$p}{canon}' not found")
             if ( ! $self->{seen}{$p} );
     }


### PR DESCRIPTION
Hello again,

I changed an option name in my `@spec` and forgot to change it in `validate({requires => [...]})`.
Before this commit, that produced the following output:

```
Use of uninitialized value in concatenation (.) or string at ../getopt-lucid/Getopt-Lucid-1.06/lib/Getopt/Lucid.pm line 239.
Required option '' not found
```

With this commit:

```
Requiring an unspecified option ('foo') in validate()
```

Besides, this is not a `G::Lucid::Exception::ARGV` anymore (was catchable as
a mere user command-line mistake) but a `G::Lucid::Exception::Spec`. (I was not sure what was best between that and `G::Lucid::Exception::Usage`, but after all that's more about invalid specification than invalid method call.)

Cheers,
