### PR TITLE
validate() takes a hashref, reflect that in synopsis

### DIFF
--- a/lib/Getopt/Lucid.pm
+++ b/lib/Getopt/Lucid.pm
@@ -825,7 +825,7 @@ __END__
     Param("help")->anycase,            # case insensitivity
   );
   $opt = Getopt::Lucid->getopt( \@adv_spec );
-  $opt->validate( 'requires' => ['input'] );
+  $opt->validate({ 'requires' => ['input'] });
 
   # example with a config file
 


### PR DESCRIPTION
validate() expects a hashref, but the synopsis showed it being called with a hash.