### PR TITLE
add indication that an option takes a value to the help message

### DIFF
--- a/lib/Getopt/Lucid.pm
+++ b/lib/Getopt/Lucid.pm
@@ -27,7 +27,7 @@ my $VALID_NAME      = qr/$VALID_LONG|$VALID_SHORT|$VALID_BARE/;
 my $SHORT_BUNDLE    = qr/-[$VALID_STARTCHAR]{2,}/;
 my $NEGATIVE        = qr/(?:--)?no-/;
 
-my @valid_keys = qw( name type default nocase valid needs canon doc );
+my @valid_keys = qw( name type default nocase valid needs canon doc placeholder );
 my @valid_types = qw( switch counter parameter list keypair);
 
 sub Switch  {
@@ -95,6 +95,8 @@ sub anycase { my $self = shift; $self->{nocase}=1; return $self };
 sub needs { my $self = shift; $self->{needs}=[@_]; return $self };
 
 sub doc { my $self = shift; $self->{doc}=shift; return $self };
+
+sub placeholder { my $self = shift; $self->{placeholder}=shift; return $self };
 
 sub _clone { my $self = shift; bless { %$self }, ref $self }
 
@@ -385,7 +387,7 @@ sub usage {
     for my $opt ( sort { $a->{strip} cmp $b->{strip} } values %{$self->{spec}} ) {
         my $names = [ @{ $opt->{names} } ];
         push @doc, [
-            _build_usage_left_column( $names, \@short_opts, $opt->{type} ),
+            _build_usage_left_column( $names, \@short_opts, $opt->{type}, $opt->{placeholder} ),
             _build_usage_right_column( $opt->{doc}, $opt->{default}, $opt->{type} ),
         ];
     }
@@ -400,7 +402,7 @@ sub usage {
 }
 
 sub _build_usage_left_column {
-    my ($names, $all_short_opts, $type) = @_;
+    my ($names, $all_short_opts, $type, $placeholder ) = @_;
     my @sorted_names =
       sort { length $a <=> length $b } map { my $s = $_; $s =~ s/^-*//; $s } @$names;
 
@@ -409,10 +411,11 @@ sub _build_usage_left_column {
 
     push @$all_short_opts, @short_opts;
 
+    $placeholder = 'value' if ! defined $placeholder;
     my $value =
-          $type eq 'keypair' ? ' key=<value>'
-        : $type eq 'counter' ? ' [<value>]'
-        : $type ne 'switch'  ? ' <value>'
+          $type eq 'keypair' ? " key=<$placeholder>"
+        : $type eq 'counter' ? " [<$placeholder>]"
+        : $type ne 'switch'  ? " <$placeholder>"
         :                      ''
         ;
 
@@ -1113,6 +1116,26 @@ Sets the documentation string for an option.
     );
 
 This string shows up in the "usage" method.
+
+=== placeholder()
+
+Sets the string used for the value placeholder in the usage for an option.
+If not specified, defaults to C<value>.
+
+For example,
+
+    @spec = (
+      Param("output")->doc("write output to the specified file")
+                     ->placeholder("file"),
+    );
+
+results in
+
+  --output <file>      write output to the specified file
+
+rather than the default of
+
+  --output <value>      write output to the specified file
 
 == Validation
 

--- a/t/11-usage.t
+++ b/t/11-usage.t
@@ -19,7 +19,7 @@ my $prog = basename($0);
 my $spec = [
     Counter("--verbose|v")->doc("turn on verbose output")->default(2),
     Switch("--test")->doc("run in test mode"),
-    Param("--input")->default("test.txt"),
+    Param("--input")->default("test.txt")->placeholder('file'),
     Switch("-r")->doc("recursive"),
     Param("bare"),
     List("libs")->default(qw/one two/),
@@ -30,7 +30,7 @@ my @expectations = (
     qr/^Usage: \Q$prog\E \[-rv] \[long options] \[arguments]$/,
     qr/^\s+--bare <value>\s*$/,
     qr/^\s+--define key=<value>\s+\(default: arch=i386, isize=4\)$/,
-    qr/^\s+--input <value>\s+\(default: test\.txt\)$/,
+    qr/^\s+--input <file>\s+\(default: test\.txt\)$/,
     qr/^\s+--libs <value> \s+\(default: one, two\)$/,
     qr/^\s+-r\s+recursive$/,
     qr/^\s+--test\s+run in test mode$/,

--- a/t/11-usage.t
+++ b/t/11-usage.t
@@ -28,13 +28,13 @@ my $spec = [
 
 my @expectations = (
     qr/^Usage: \Q$prog\E \[-rv] \[long options] \[arguments]$/,
-    qr/^\s+--bare\s*$/,
-    qr/^\s+--define\s+\(default: arch=i386, isize=4\)$/,
-    qr/^\s+--input\s+\(default: test\.txt\)$/,
-    qr/^\s+--libs\s+\(default: one, two\)$/,
+    qr/^\s+--bare <value>\s*$/,
+    qr/^\s+--define key=<value>\s+\(default: arch=i386, isize=4\)$/,
+    qr/^\s+--input <value>\s+\(default: test\.txt\)$/,
+    qr/^\s+--libs <value> \s+\(default: one, two\)$/,
     qr/^\s+-r\s+recursive$/,
     qr/^\s+--test\s+run in test mode$/,
-    qr/^\s+-v, --verbose\s+turn on verbose output \(default: 2\)$/,
+    qr/^\s+-v \[<value>\], --verbose \[<value>\]\s+turn on verbose output \(default: 2\)$/,
 );
 
 plan tests => 2 + @expectations;


### PR DESCRIPTION
The help message didn't specify that an option took a value.

Here's before and after for the option specification in t/11-usage.t

```
Usage: 11-usage.t [-rv] [long options] [arguments]
	--bare
	--define                 (default: arch=i386, isize=4)
	--input                  (default: test.txt)
	--libs                   (default: one, two)
	-r                       recursive
	--test                   run in test mode
	-v, --verbose            turn on verbose output (default: 2)

```
```
Usage: 11-usage.t [-rv] [long options] [arguments]
	--bare <value>
	--define key=<value>     (default: arch=i386, isize=4)
	--input <value>          (default: test.txt)
	--libs <value>           (default: one, two)
	-r                       recursive
	--test                   run in test mode
	-v [<value>], --verbose [<value>] turn on verbose output (default: 2)
```